### PR TITLE
hotfix: change parameter input from Korean to English

### DIFF
--- a/src/main/java/com/itmoji/itmojiserver/api/v1/announcement/SearchType.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/announcement/SearchType.java
@@ -17,7 +17,7 @@ public enum SearchType {
 
     public static SearchType findSearchType(final String type) {
         return Arrays.stream(SearchType.values())
-                .filter(searchType -> searchType.type.equals(type))
+                .filter(searchType -> searchType.name().equalsIgnoreCase(type))
                 .findAny()
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 검색 타입입니다."));
     }


### PR DESCRIPTION
# What

 change parameter input from Korean to English

# why?

changed the parameter input to English to maintain consistency with other parameters.  
