### PR TITLE
[MOJI-5] feat: implement global exception handling with ErrorCode and ErrorResponse

### DIFF
--- a/src/main/java/com/itmoji/itmojiserver/api/v1/error/ErrorCode.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/error/ErrorCode.java
@@ -1,0 +1,54 @@
+package com.itmoji.itmojiserver.api.v1.error;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@Getter
+public enum ErrorCode {
+
+  /*
+   * 기본 10개, 예외가 많을 것 같다면 20개 단위로 코드 번호 부여
+   * 1. Common : C001 ~ C030
+   * 2. Session : C031 ~ C040
+   */
+
+  // Common
+  INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST.value(), "C001", " 잘못된 입력값입니다."),
+  METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED.value(), "C002", " 요청메서드가 허용되지 않습니다."),
+  ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "C003", " Entity가 존재하지 않습니다."),
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "C004", "서버에서 오류가 발생했습니다."),
+  INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST.value(), "C005", " 잘못된 타입입니다."),
+  HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "C006", "권한이 없습니다."),
+  INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST.value(), "C007", "Json형식과 맞지 않습니다."),
+  INVALID_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST.value(), "C008", " 요청 파라미터의 타입이 잘못되었습니다."),
+  FAIL_REQUEST_PARAMETER_VALIDATION(HttpStatus.BAD_REQUEST.value(), "C009", "요청 파라미터의 유효성이 맞지 않습니다."),
+  BIND_ERROR(HttpStatus.BAD_REQUEST.value(), "C010", " 바인딩 에러가 발생했습니다. 파라미터를 확인해주세요."),
+  ILLEGAL_ARGUMENT(HttpStatus.BAD_REQUEST.value(), "C011", "illegalArgument error"),
+  NOT_FOUND(HttpStatus.NOT_FOUND.value(), "C012", "페이지를 찾을 수 없습니다."),
+
+  // Session
+  SESSION_NOT_FOUND(HttpStatus.UNAUTHORIZED.value(), "C031", "세션이 존재하지 않거나 세션 ID가 존재하지 않습니다."),
+  SESSION_INVALID__USER(HttpStatus.UNAUTHORIZED.value(), "C032","유효하지 않은 유저입니다."),
+  SESSION_RESIGNED_USER(HttpStatus.UNAUTHORIZED.value(), "C033", "탈퇴한 회원입니다.");
+
+  private final int status;
+  private final String code;
+  private String message;
+
+  ErrorCode(final int status, final String code, final String message) {
+    this.status = status;
+    this.code = code;
+    this.message = message;
+  }
+
+  public void updateIllegalArgumentExceptionMessage(final String message) {
+    if (this == ILLEGAL_ARGUMENT) {
+      this.message = message;
+    } else {
+      throw new UnsupportedOperationException("Cannot set message for this error code");
+    }
+  }
+}

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/error/ErrorResponse.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/error/ErrorResponse.java
@@ -1,0 +1,122 @@
+package com.itmoji.itmojiserver.api.v1.error;
+
+import jakarta.validation.ConstraintViolation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+
+  private String message;
+  private int status;
+  private List<FieldError> errors;
+  private String code;
+
+
+  private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+    this.message = code.getMessage();
+    this.status = code.getStatus();
+    this.errors = errors;
+    this.code = code.getCode();
+  }
+
+  private ErrorResponse(final ErrorCode code) {
+    this.message = code.getMessage();
+    this.status = code.getStatus();
+    this.code = code.getCode();
+    this.errors = new ArrayList<>();
+  }
+
+  private ErrorResponse(final ErrorCode code, final Set<ConstraintViolation<?>> violations) {
+    this.message = code.getMessage();
+    this.status = code.getStatus();
+    this.errors = violations.stream()
+        .map(violation -> new FieldError(
+            violation.getPropertyPath().toString(),
+            violation.getInvalidValue() == null ? "" : violation.getInvalidValue().toString(),
+            violation.getMessage()
+        ))
+        .collect(Collectors.toList());
+    this.code = code.getCode();
+  }
+
+  private ErrorResponse(final ErrorCode code, final MethodParameter parameter) {
+    this.message = code.getMessage();
+    this.status = code.getStatus();
+    this.code = code.getCode();
+    this.errors = new ArrayList<>();
+    this.errors.add(new FieldError(
+        Objects.requireNonNull(parameter.getParameterName()),
+        parameter.getParameterType().getSimpleName(),
+        "Type mismatch"
+    ));
+  }
+
+  public static ErrorResponse of(final ErrorCode code, final Set<ConstraintViolation<?>> violations) {
+    return new ErrorResponse(code, violations);
+  }
+
+
+  public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+    return new ErrorResponse(code, FieldError.of(bindingResult));
+  }
+
+  public static ErrorResponse of(final ErrorCode code) {
+    return new ErrorResponse(code);
+  }
+
+  public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
+    return new ErrorResponse(code, errors);
+  }
+
+  public static ErrorResponse of(final MethodArgumentTypeMismatchException e) {
+    final String value = e.getValue() == null ? "" : e.getValue().toString();
+    final List<FieldError> errors = FieldError.of(e.getName(), value, e.getErrorCode());
+    return new ErrorResponse(ErrorCode.INVALID_TYPE_VALUE, errors);
+  }
+
+  public static ErrorResponse of(final ErrorCode code, final MethodParameter parameter) {
+    return new ErrorResponse(code, parameter);
+  }
+
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class FieldError {
+    private String field;
+    private String value;
+    private String reason;
+
+    private FieldError(final String field, final String value, final String reason) {
+      this.field = field;
+      this.value = value;
+      this.reason = reason;
+    }
+
+    public static List<FieldError> of(final String field, final String value, final String reason) {
+      List<FieldError> fieldErrors = new ArrayList<>();
+      fieldErrors.add(new FieldError(field, value, reason));
+      return fieldErrors;
+    }
+
+    private static List<FieldError> of(final BindingResult bindingResult) {
+      final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+      return fieldErrors.stream()
+          .map(error -> new FieldError(
+              error.getField(),
+              error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+              error.getDefaultMessage()))
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/error/GlobalExceptionHandler.java
@@ -1,0 +1,120 @@
+package com.itmoji.itmojiserver.api.v1.error;
+
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    /**
+     * 400 Bad Request - IllegalArgumentException 메시지를 변수로 받음
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error("handleIllegalArgumentException", e);
+        ErrorCode errorCode = ErrorCode.ILLEGAL_ARGUMENT;
+        errorCode.updateIllegalArgumentExceptionMessage(e.getMessage());
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 400 Bad Request - 요청 파라미터의 유효성 검사가 실패했을 때 발생
+     *
+     * @Valid @Validated 사용하여 유효성 검사 실패할 시 발생
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("handleMethodArgumentNotValidException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.FAIL_REQUEST_PARAMETER_VALIDATION,
+                e.getBindingResult());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 400 Bad Request - json 형식 자체가 맞지 않을 경우 발생 콤마가 빠지거나 list형식인데 대괄호가 없음
+     */
+    @ExceptionHandler(HttpMessageConversionException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpMessageConversionException(HttpMessageConversionException e) {
+        log.error("handleHttpMessageConversionException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 400 Bad Request - 요청 파라미터의 타입이 맞지 않을 때 발생
+     *
+     * @RequestParam enum으로 binding 못했을 경우도 발생
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e) {
+        log.error("handleMethodArgumentTypeMismatchException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_REQUEST_PARAMETER, e.getParameter());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * @ModelAttribute 으로 binding error 발생시 BindException 발생한다. ref
+     * https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-ann-modelattrib-method-args
+     */
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        log.error("handleBindException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.BIND_ERROR, e.getBindingResult());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 지원하지 않은 HTTP method 호출 할 경우 발생
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    /**
+     * 400 Bad Request - 유효성 검사가 실패했을 때 발생
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+        log.error("handleConstraintViolationException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.FAIL_REQUEST_PARAMETER_VALIDATION,
+                e.getConstraintViolations());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 500 Internal Server Exception - 통합
+     */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("handleException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * 404 Not Found Exception - 엔드포인트를 찾을 수 없을떄
+     */
+    @ExceptionHandler(NoHandlerFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException e) {
+        log.error("NoHandlerFoundException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.NOT_FOUND);
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+}


### PR DESCRIPTION
# What
- Added a global exception handling mechanism
- Created `ErrorCode` enum to define standardized error codes and messages
- Developed `ErrorResponse` class to format error responses consistently
- Implemented `GlobalExceptionHandler` to handle common exceptions like validation errors and type mismatches

# Why?
- To provide a centralized and maintainable way to handle exceptions across the application
- To improve error logging, debugging, and client error responses
- To enforce consistency in error codes and response formats

