### PR TITLE
[MOJI-28] refactor: Separate condition key into type and detail ID

### DIFF
--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/BadgeCondition.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/BadgeCondition.java
@@ -23,7 +23,12 @@ public class BadgeCondition {
 
     private Long badgeConditionGroupId;
 
-    private String conditionKey;
+    @Enumerated(EnumType.STRING)
+    private AttendanceOptions conditionKey;
+
+    @Column(name = "detail_key_id")
+    private Long detailKeyId;
+
     private int count;
 
     @Enumerated(EnumType.STRING)
@@ -34,15 +39,17 @@ public class BadgeCondition {
     }
 
     @Builder
-    public BadgeCondition(Long badgeConditionGroupId, String key, int count, Range range) {
+    public BadgeCondition(Long badgeConditionGroupId, AttendanceOptions key, Long detailKeyId, int count, Range range) {
         this.badgeConditionGroupId = badgeConditionGroupId;
         this.conditionKey = key;
+        this.detailKeyId = detailKeyId;
         this.count = count;
         this.conditionRange = range;
     }
 
-    public void update(String key, int count, Range range) {
+    public void update(AttendanceOptions key, Long detailKeyId, int count, Range range) {
         this.conditionKey = key;
+        this.detailKeyId = detailKeyId;
         this.count = count;
         this.conditionRange = range;
     }

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/BadgeConditionDTO.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/BadgeConditionDTO.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 @Setter
 public class BadgeConditionDTO {
     private String key;
+    private long detailKeyId;
     private int count;
     private String range;
 }

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/BadgeConditionRequest.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/BadgeConditionRequest.java
@@ -3,33 +3,10 @@ package com.itmoji.itmojiserver.api.v1.attendance.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public class BadgeConditionRequest {
-
-    @NotBlank(message = "조건 key는 필수 입력 값입니다.")
-    private String key;
-
-    @NotNull(message = "count는 필수 입력 값입니다.")
-    private Integer count;
-
-    @NotBlank(message = "range는 필수 입력 값입니다.")
-    private String range;
-
-    public String getKey() {
-        return key;
-    }
-    public void setKey(String key) {
-        this.key = key;
-    }
-    public Integer getCount() {
-        return count;
-    }
-    public void setCount(Integer count) {
-        this.count = count;
-    }
-    public String getRange() {
-        return range;
-    }
-    public void setRange(String range) {
-        this.range = range;
-    }
+public record BadgeConditionRequest(
+        @NotBlank(message = "key는 필수 입력 값입니다.") String key,
+        @NotBlank(message = "detailKey는 필수 입력 값입니다.") Long detailKeyId,
+        @NotNull(message = "count는 필수 입력 값입니다.") Integer count,
+        @NotBlank(message = "range는 필수 입력 값입니다.") String range
+) {
 }

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/ConditionCreateRequest.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/ConditionCreateRequest.java
@@ -15,6 +15,9 @@ public class ConditionCreateRequest {
     @NotBlank(message = "조건 key는 필수 입력 값입니다.")
     private String key;
 
+    @NotBlank(message = "조건 detailKey는 필수 입력 값입니다.")
+    private Long detailKey;
+
     @NotNull(message = "count는 필수 입력 값입니다.")
     private Integer count;
 

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/ConditionDTO.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/ConditionDTO.java
@@ -1,28 +1,4 @@
 package com.itmoji.itmojiserver.api.v1.attendance.dto;
 
-public class ConditionDTO {
-    private Long id;
-    private String key;
-    private int count;
-    private String range; // "MORE" 또는 "LESS"
-
-    public ConditionDTO(Long id, String key, int count, String range) {
-        this.id = id;
-        this.key = key;
-        this.count = count;
-        this.range = range;
-    }
-
-    public Long getId() {
-        return id;
-    }
-    public String getKey() {
-        return key;
-    }
-    public int getCount() {
-        return count;
-    }
-    public String getRange() {
-        return range;
-    }
+public record ConditionDTO(Long id, String key, Long detailKey, int count, String range) {
 }

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/ConditionUpdateRequest.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/ConditionUpdateRequest.java
@@ -2,16 +2,11 @@ package com.itmoji.itmojiserver.api.v1.attendance.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
 
-@Getter
-public class ConditionUpdateRequest {
-    @NotBlank(message = "조건 key는 필수 입력 값입니다.")
-    private String key;
-
-    @NotNull(message = "count는 필수 입력 값입니다.")
-    private Integer count;
-
-    @NotBlank(message = "range는 필수 입력 값입니다.")
-    private String range;
+public record ConditionUpdateRequest(
+        @NotBlank(message = "key는 필수 입력 값입니다.") String key,
+        @NotBlank(message = "detailKeyId는 필수 입력 값입니다.") Long detailKeyId,
+        @NotNull(message = "count는 필수 입력 값입니다.") Integer count,
+        @NotBlank(message = "range는 필수 입력 값입니다.") String range
+) {
 }

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/service/BadgeService.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/service/BadgeService.java
@@ -1,5 +1,6 @@
 package com.itmoji.itmojiserver.api.v1.attendance.service;
 
+import com.itmoji.itmojiserver.api.v1.attendance.AttendanceOptions;
 import com.itmoji.itmojiserver.api.v1.attendance.Badge;
 import com.itmoji.itmojiserver.api.v1.attendance.BadgeCondition;
 import com.itmoji.itmojiserver.api.v1.attendance.BadgeConditionGroup;
@@ -13,9 +14,11 @@ import com.itmoji.itmojiserver.api.v1.attendance.dto.ConditionCreateRequest;
 import com.itmoji.itmojiserver.api.v1.attendance.dto.ConditionDTO;
 import com.itmoji.itmojiserver.api.v1.attendance.dto.ConditionGroupDTO;
 import com.itmoji.itmojiserver.api.v1.attendance.dto.ConditionUpdateRequest;
+import com.itmoji.itmojiserver.api.v1.attendance.repository.AttendanceOptionRepository;
 import com.itmoji.itmojiserver.api.v1.attendance.repository.BadgeConditionGroupRepository;
 import com.itmoji.itmojiserver.api.v1.attendance.repository.BadgeConditionRepository;
 import com.itmoji.itmojiserver.api.v1.attendance.repository.BadgeRepository;
+import com.itmoji.itmojiserver.api.v1.attendance.repository.DetailOptionRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -30,6 +33,8 @@ public class BadgeService {
     private final BadgeRepository badgeRepository;
     private final BadgeConditionGroupRepository groupRepository;
     private final BadgeConditionRepository conditionRepository;
+    private final DetailOptionRepository detailOptionRepository;
+    private final AttendanceOptionRepository attendanceOptionRepository;
 
     @Transactional(readOnly = true)
     public List<BadgeDTO> getBadges() {
@@ -38,6 +43,7 @@ public class BadgeService {
                 .toList();
     }
 
+
     @Transactional(readOnly = true)
     public List<BadgeWithConditionsDTO> getBadgesWithConditions() {
         List<Badge> badges = badgeRepository.findAll();
@@ -45,10 +51,14 @@ public class BadgeService {
             List<BadgeConditionGroup> groups = groupRepository.findByBadgeId(badge.getId());
             List<ConditionGroupDTO> groupDTOs = groups.stream().map(group -> {
                 List<BadgeCondition> conditions = conditionRepository.findByBadgeConditionGroupId(group.getId());
+
                 List<ConditionDTO> conditionDTOs = conditions.stream().map(condition ->
-                                new ConditionDTO(condition.getId(), condition.getConditionKey(), condition.getCount(),
-                                        condition.getConditionRange().name()))
-                        .toList();
+                        new ConditionDTO(condition.getId(),
+                                condition.getConditionKey().name(),
+                                condition.getDetailKeyId(),
+                                condition.getCount(),
+                                condition.getConditionRange().name())).toList();
+
                 return new ConditionGroupDTO(group.getId(), conditionDTOs);
             }).toList();
             return new BadgeWithConditionsDTO(badge.getId(), badge.getIcon(), badge.getName(), groupDTOs);
@@ -69,18 +79,11 @@ public class BadgeService {
                     "The condition group does not belong to the specified badge.");
         }
 
-        BadgeCondition.Range rangeEnum;
-        if ("more".equalsIgnoreCase(request.getRange())) {
-            rangeEnum = BadgeCondition.Range.MORE;
-        } else if ("less".equalsIgnoreCase(request.getRange())) {
-            rangeEnum = BadgeCondition.Range.LESS;
-        } else {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid range value: " + request.getRange());
-        }
-
+        BadgeCondition.Range rangeEnum = parseRange(request.getRange());
         BadgeCondition condition = new BadgeCondition(
                 request.getBadgeConditionGroupId(),
-                request.getKey(),
+                AttendanceOptions.valueOf(request.getKey()),
+                request.getDetailKey(),
                 request.getCount(),
                 rangeEnum
         );
@@ -100,19 +103,20 @@ public class BadgeService {
 
             for (BadgeConditionRequest conditionReq : groupOptions) {
                 BadgeCondition.Range rangeEnum;
-                if ("more".equalsIgnoreCase(conditionReq.getRange())) {
+                if ("more".equalsIgnoreCase(conditionReq.range())) {
                     rangeEnum = BadgeCondition.Range.MORE;
-                } else if ("less".equalsIgnoreCase(conditionReq.getRange())) {
+                } else if ("less".equalsIgnoreCase(conditionReq.range())) {
                     rangeEnum = BadgeCondition.Range.LESS;
                 } else {
                     throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                            "유효하지 않은 range 값입니다: " + conditionReq.getRange());
+                            "유효하지 않은 range 값입니다: " + conditionReq.range());
                 }
 
                 BadgeCondition condition = new BadgeCondition(
                         group.getId(),
-                        conditionReq.getKey(),
-                        conditionReq.getCount(),
+                        AttendanceOptions.valueOf(conditionReq.key().toUpperCase()),
+                        conditionReq.detailKeyId(),
+                        conditionReq.count(),
                         rangeEnum
                 );
                 conditionRepository.save(condition);
@@ -123,32 +127,19 @@ public class BadgeService {
     @Transactional
     public void updateCondition(Long badgeId, Long conditionId, ConditionUpdateRequest request) {
         badgeRepository.findById(badgeId)
-                .orElseThrow(
-                        () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Badge not found with id: " + badgeId));
-
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않은 배지 입니다." + badgeId));
         BadgeCondition condition = conditionRepository.findById(conditionId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
-                        "BadgeCondition not found with id: " + conditionId));
-
+                .orElseThrow(() -> new IllegalArgumentException("배지 조건이 존재하지 않습니다. " + conditionId));
         BadgeConditionGroup group = groupRepository.findById(condition.getBadgeConditionGroupId())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
-                        "BadgeConditionGroup not found for condition."));
+                .orElseThrow(() -> new IllegalArgumentException("배지 조건 그룹이 존재하지 않습니다."));
+
         if (!group.getBadgeId().equals(badgeId)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                    "The condition does not belong to the specified badge.");
+            throw new IllegalArgumentException("해당 컨디션이 배지에 속하지 않습니다.");
         }
+        BadgeCondition.Range rangeEnum = parseRange(request.range());
 
-        // range 문자열을 enum으로 변환
-        BadgeCondition.Range rangeEnum;
-        if ("more".equalsIgnoreCase(request.getRange())) {
-            rangeEnum = BadgeCondition.Range.MORE;
-        } else if ("less".equalsIgnoreCase(request.getRange())) {
-            rangeEnum = BadgeCondition.Range.LESS;
-        } else {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid range value: " + request.getRange());
-        }
-
-        condition.update(request.getKey(), request.getCount(), rangeEnum);
+        condition.update(AttendanceOptions.valueOf(request.key().toUpperCase()), request.detailKeyId(), request.count(),
+                rangeEnum);
         conditionRepository.save(condition);
     }
 
@@ -185,7 +176,8 @@ public class BadgeService {
                     BadgeCondition.Range rangeEnum = parseRange(condDTO.getRange());
                     BadgeCondition newCondition = BadgeCondition.builder()
                             .badgeConditionGroupId(newGroup.getId())
-                            .key(condDTO.getKey())
+                            .key(AttendanceOptions.valueOf(condDTO.getKey()))
+                            .detailKeyId(condDTO.getDetailKeyId())
                             .count(condDTO.getCount())
                             .range(rangeEnum)
                             .build();
@@ -240,7 +232,8 @@ public class BadgeService {
                     List<ConditionDTO> conditionDTOs = conditions.stream()
                             .map(condition -> new ConditionDTO(
                                     condition.getId(),
-                                    condition.getConditionKey(),
+                                    condition.getConditionKey().name(),
+                                    condition.getDetailKeyId(),
                                     condition.getCount(),
                                     condition.getConditionRange().name()
                             ))


### PR DESCRIPTION
# What

- Replaced the single String conditionKey field with
  - AttendanceOptions conditionKey (as an enum)
  - Long detailKeyId
- Updated related DTOs and request classes accordingly
- Refactored service layer logic to use the new structure
- Improved enum parsing and exception handling for robustness




# Why?
- To clearly separate the type and detail of the condition key
  - conditionKey now represents the type of condition
  - detailKeyId holds the specific detail ID
- This separation enhances maintainability and prepares the structure for potential future features that may depend on condition type