### PR TITLE
fix: make lookup work even without identifier emoji

### DIFF
--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/repository/DetailOptionRepository.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/repository/DetailOptionRepository.java
@@ -11,4 +11,7 @@ public interface DetailOptionRepository extends JpaRepository<DetailOption, Long
 
     @Query("SELECT do FROM DetailOption do WHERE do.attendanceOption = :attendanceOption")
     List<DetailOption> findByOption(AttendanceOption attendanceOption);
+
+    @Query("SELECT do FROM DetailOption do WHERE do.attendanceOption.code = :attendanceOptions")
+    List<DetailOption> findByAttendanceOptions(AttendanceOptions attendanceOptions);
 }


### PR DESCRIPTION
# what

modified the lookup logic to allow queries without requiring the identifier emoji


# why?

- to improve user experience by supporting more flexible input formats
- Users might omit the emoji, so making it optional enhances usability