### PR TITLE
refactor BadgeConditionDTO and improve detail option handling

### DIFF
--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/AttendanceOptions.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/AttendanceOptions.java
@@ -1,5 +1,6 @@
 package com.itmoji.itmojiserver.api.v1.attendance;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;
 
 public enum AttendanceOptions {
@@ -23,6 +24,15 @@ public enum AttendanceOptions {
         return Arrays.stream(AttendanceOptions.values())
                 .filter(attendanceOptions -> attendanceOptions.name().equals(category.toUpperCase()))
                 .findAny()
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않은 출석 옵션입니다." + category));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않은 출석 옵션이에요: " + category));
+    }
+
+    @JsonCreator
+    public static AttendanceOptions from(String category) {
+        try {
+            return AttendanceOptions.valueOf(category.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("존재하지 않은 출석 옵션이에요: " + category);
+        }
     }
 }

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/BadgeConditionDTO.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/BadgeConditionDTO.java
@@ -1,12 +1,13 @@
 package com.itmoji.itmojiserver.api.v1.attendance.dto;
 
+import com.itmoji.itmojiserver.api.v1.attendance.AttendanceOptions;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class BadgeConditionDTO {
-    private String key;
+    private AttendanceOptions key;
     private long detailKeyId;
     private int count;
     private String range;

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/ConditionCreateRequest.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/ConditionCreateRequest.java
@@ -1,5 +1,6 @@
 package com.itmoji.itmojiserver.api.v1.attendance.dto;
 
+import com.itmoji.itmojiserver.api.v1.attendance.AttendanceOptions;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -9,13 +10,13 @@ public class ConditionCreateRequest {
     @NotNull(message = "배지 id는 필수 입력 값입니다.")
     private Long badgeId;
 
-    @NotNull(message = "조건 그룹 ID는 필수 입력 값입니다.")
+    @NotNull(message = "그룹 ID는 필수 입력 값입니다.")
     private Long badgeConditionGroupId;
 
-    @NotBlank(message = "조건 key는 필수 입력 값입니다.")
-    private String key;
+    @NotBlank(message = "key는 필수 입력 값입니다.")
+    private AttendanceOptions key;
 
-    @NotBlank(message = "조건 detailKey는 필수 입력 값입니다.")
+    @NotBlank(message = "detailKey는 필수 입력 값입니다.")
     private Long detailKeyId;
 
     @NotNull(message = "count는 필수 입력 값입니다.")

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/ConditionUpdateRequest.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/dto/ConditionUpdateRequest.java
@@ -1,10 +1,11 @@
 package com.itmoji.itmojiserver.api.v1.attendance.dto;
 
+import com.itmoji.itmojiserver.api.v1.attendance.AttendanceOptions;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record ConditionUpdateRequest(
-        @NotBlank(message = "key는 필수 입력 값입니다.") String key,
+        @NotBlank(message = "key는 필수 입력 값입니다.") AttendanceOptions key,
         @NotBlank(message = "detailKeyId는 필수 입력 값입니다.") Long detailKeyId,
         @NotNull(message = "count는 필수 입력 값입니다.") Integer count,
         @NotBlank(message = "range는 필수 입력 값입니다.") String range

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/repository/AttendanceOptionRepository.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/repository/AttendanceOptionRepository.java
@@ -15,4 +15,6 @@ public interface AttendanceOptionRepository extends JpaRepository<AttendanceOpti
 
     @Query("SELECT ao FROM AttendanceOption ao WHERE ao.code = :attendanceOptions")
     Optional<AttendanceOption> findByOptions(AttendanceOptions attendanceOptions);
+
+    Optional<AttendanceOption> findByName(String code);
 }

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/service/AttendanceService.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/service/AttendanceService.java
@@ -13,7 +13,6 @@ import com.itmoji.itmojiserver.api.v1.attendance.repository.DetailOptionReposito
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,10 +55,13 @@ public class AttendanceService {
     }
 
     @Transactional
-    public void addDetailOption(final AttendanceOptions options, final String name ) {
+    public void addDetailOption(final AttendanceOptions options, final String name) {
+
+        attendanceOptionRepository.findByName(name)
+                .orElseThrow(() -> new IllegalArgumentException("이미 같은 이름의 배지가 존재해요"));
 
         final AttendanceOption option = attendanceOptionRepository.findByOptions(options)
-                .orElseThrow(() -> new IllegalArgumentException("해당 출석 옵션을 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 출석 옵션을 존재하지 않아요"));
 
         // 2) DetailOption 생성
         DetailOption newDetailOption = new DetailOption(name);

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/service/BadgeService.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/service/BadgeService.java
@@ -82,7 +82,7 @@ public class BadgeService {
         BadgeCondition.Range rangeEnum = parseRange(request.getRange());
         BadgeCondition condition = new BadgeCondition(
                 request.getBadgeConditionGroupId(),
-                AttendanceOptions.valueOf(request.getKey()),
+                request.getKey(),
                 request.getDetailKeyId(),
                 request.getCount(),
                 rangeEnum
@@ -102,15 +102,7 @@ public class BadgeService {
             group = groupRepository.save(group);
 
             for (BadgeConditionRequest conditionReq : groupOptions) {
-                BadgeCondition.Range rangeEnum;
-                if ("more".equalsIgnoreCase(conditionReq.range())) {
-                    rangeEnum = BadgeCondition.Range.MORE;
-                } else if ("less".equalsIgnoreCase(conditionReq.range())) {
-                    rangeEnum = BadgeCondition.Range.LESS;
-                } else {
-                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                            "유효하지 않은 range 값입니다: " + conditionReq.range());
-                }
+                BadgeCondition.Range rangeEnum = parseRange(conditionReq.range());
 
                 BadgeCondition condition = new BadgeCondition(
                         group.getId(),
@@ -138,7 +130,7 @@ public class BadgeService {
         }
         BadgeCondition.Range rangeEnum = parseRange(request.range());
 
-        condition.update(AttendanceOptions.valueOf(request.key().toUpperCase()), request.detailKeyId(), request.count(),
+        condition.update(request.key(), request.detailKeyId(), request.count(),
                 rangeEnum);
         conditionRepository.save(condition);
     }
@@ -174,9 +166,12 @@ public class BadgeService {
             if (conditionsList != null) {
                 for (BadgeConditionDTO condDTO : conditionsList) {
                     BadgeCondition.Range rangeEnum = parseRange(condDTO.getRange());
+                    detailOptionRepository.findById(condDTO.getDetailKeyId())
+                            .orElseThrow(() -> new IllegalArgumentException(
+                                    "존재하지 않는 detailKeyId 입니다 :" + condDTO.getDetailKeyId()));
                     BadgeCondition newCondition = BadgeCondition.builder()
                             .badgeConditionGroupId(newGroup.getId())
-                            .key(AttendanceOptions.valueOf(condDTO.getKey()))
+                            .key(condDTO.getKey())
                             .detailKeyId(condDTO.getDetailKeyId())
                             .count(condDTO.getCount())
                             .range(rangeEnum)

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/service/ParsingOptionService.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/service/ParsingOptionService.java
@@ -51,7 +51,7 @@ public class ParsingOptionService {
         final List<AttendanceDetailOptionDTO> detailOptionDTOs = detailOptions.stream()
                 .map(o -> attendanceDetailOptionRepository.findById(o.getId())
                         .map(option -> new AttendanceDetailOptionDTO(o.getId(), o.getName(), option.getIdentifier()))
-                        .orElseGet(() -> new AttendanceDetailOptionDTO(o.getId(), o.getName(), null)))
+                        .orElseGet(() -> new AttendanceDetailOptionDTO(o.getId(), o.getName(), o.getName())))
                 .toList();
 
         return new ParsingOptionsDTO(delimiterDTO, dayMappingDTO, options.getName(), detailOptionDTOs);
@@ -98,7 +98,20 @@ public class ParsingOptionService {
             detailOptionsBox.add(attendanceDetailOption);
         }
 
+        validateIdentifier(detailOptionsBox);
+
         attendanceDetailOptionRepository.saveAll(detailOptionsBox);
+    }
+
+    private void validateIdentifier(final List<AttendanceDetailOption> detailOptionDTOs) {
+        long uniqueIdentifierCount = detailOptionDTOs.stream()
+                .map(AttendanceDetailOption::getIdentifier)
+                .distinct()
+                .count();
+
+        if (uniqueIdentifierCount != detailOptionDTOs.size()) {
+            throw new IllegalArgumentException("Identifier 값이 중복되었습니다.");
+        }
     }
 
     @Transactional


### PR DESCRIPTION
# 🔧 What
Implemented findByName method

- Added custom @JsonCreator in AttendanceOptions to support case-insensitive enum deserialization
- Added name validation when creating detail options
- Set default value of detailOption identifier to its name
- Changed key type in BadgeConditionDTO from String to AttendanceOptions enum

# ❓ Why
- To enable flexible and safe enum parsing from JSON requests regardless of case
- To ensure data integrity by validating detail option names upon creation
- To reduce redundancy and ensure consistency by using the name as the default identifier
- To enhance type safety and prevent invalid values by using enums instead of raw strings in DTOs