### PR TITLE
fix: name duplication

### DIFF
--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/repository/DetailOptionRepository.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/repository/DetailOptionRepository.java
@@ -4,6 +4,7 @@ import com.itmoji.itmojiserver.api.v1.attendance.AttendanceOption;
 import com.itmoji.itmojiserver.api.v1.attendance.AttendanceOptions;
 import com.itmoji.itmojiserver.api.v1.attendance.DetailOption;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -14,4 +15,6 @@ public interface DetailOptionRepository extends JpaRepository<DetailOption, Long
 
     @Query("SELECT do FROM DetailOption do WHERE do.attendanceOption.code = :attendanceOptions")
     List<DetailOption> findByAttendanceOptions(AttendanceOptions attendanceOptions);
+
+    Optional<DetailOption> findByName(String name);
 }

--- a/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/service/AttendanceService.java
+++ b/src/main/java/com/itmoji/itmojiserver/api/v1/attendance/service/AttendanceService.java
@@ -1,6 +1,7 @@
 package com.itmoji.itmojiserver.api.v1.attendance.service;
 
 
+import com.itmoji.itmojiserver.api.v1.attendance.AttendanceDetailOption;
 import com.itmoji.itmojiserver.api.v1.attendance.AttendanceOption;
 import com.itmoji.itmojiserver.api.v1.attendance.AttendanceOptions;
 import com.itmoji.itmojiserver.api.v1.attendance.Badge;
@@ -24,6 +25,7 @@ public class AttendanceService {
     private final AttendanceOptionRepository attendanceOptionRepository;
     private final DetailOptionRepository detailOptionRepository;
     private final BadgeRepository badgeRepository;
+    private final AttendanceDetailOption attendanceDetailOption;
 
     @Transactional(readOnly = true)
     public Map<String, AttendanceCategoryDTO> getAllAttendanceOptions() {
@@ -57,8 +59,10 @@ public class AttendanceService {
     @Transactional
     public void addDetailOption(final AttendanceOptions options, final String name) {
 
-        attendanceOptionRepository.findByName(name)
-                .orElseThrow(() -> new IllegalArgumentException("이미 같은 이름의 배지가 존재해요"));
+        detailOptionRepository.findByName(name)
+                .ifPresent(detailOption -> {
+                    throw new IllegalArgumentException("이미 존재하는 이름 입니다.");
+                });
 
         final AttendanceOption option = attendanceOptionRepository.findByOptions(options)
                 .orElseThrow(() -> new IllegalArgumentException("해당 출석 옵션을 존재하지 않아요"));
@@ -98,6 +102,7 @@ public class AttendanceService {
         }
 
         detailOptionRepository.delete(detailOption);
+        attendanceOptionRepository.delete(option);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
# What
Added validation to prevent creation of badge detail options with duplicate names

# Why
To ensure the uniqueness of badge detail option names and prevent conflicts or confusion during badge evaluation